### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,10 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
+  def index
+    @items = Item.order(created_at: :desc) 
+  end
+
   def new
     @item = Item.new
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,45 +127,39 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+  <% if @items.present? %>
+    <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+        <%= link_to item_path(item) do %>
+          <div class='item-img-content'>
+           <%= image_tag (item.product_image.attached? ? url_for(item.product_image) : "item-sample.png"), class: "item-img" %>
+            <%# if item.sold_out? %>
+              <%#div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+            <% end %>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.product_name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br><%= item.shipping_cost_burden.name %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
+    <% end %>
+  <% else %>
+    <li class='list'>
+      <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
+          <h3 class='item-name'>商品を出品してね！</h3>
           <div class='item-price'>
             <span>99999999円<br>(税込み)</span>
             <div class='star-btn'>
@@ -174,11 +168,10 @@
             </div>
           </div>
         </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-    </ul>
+      <% end %>
+    </li>
+  <% end %>
+</ul>
   </div>
   <%# /商品一覧 %>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
   <% if @items.present? %>
     <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to item_path(item) do %>
+        <%= link_to "#" do %>
           <div class='item-img-content'>
            <%= image_tag (item.product_image.attached? ? url_for(item.product_image) : "item-sample.png"), class: "item-img" %>
             <%# if item.sold_out? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
    devise_for :users
    root to: 'items#index'
 
-   resources :items, only: [:new, :create]
+   resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
#  What
・商品一覧ページは、ログインしていないユーザーでもアクセスできるように実装しました
・出品されている商品が一覧で表示されるようにしました

#  Why
・すべてのユーザーが商品の一覧を確認できるようにするため
・出品されている商品が一覧表示されることで視認性を高め、ユーザーが簡単に商品を確認できるようにするため

# gyazo
・商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/29cf174b3f0e88bb5cec0e5f77daab7e

・商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/a1da20949ec06593cb26589bf056460e